### PR TITLE
updates from testing in dec 2020

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,10 +2,9 @@ applications:
 - path: ./server
   memory: 512M
   instances: 1
-  domain: mybluemix.net
   name: nlc-email-phishing
   disk_quota: 1024M
   env:
     CLASSIFIER_ID: placeholder
-    NATURAL_LANGUAGE_CLASSIFIER_USERNAME: placeholder
-    NATURAL_LANGUAGE_CLASSIFIER_PASSWORD: placeholder
+    NATURAL_LANGUAGE_CLASSIFIER_APIKEY: placeholder
+    NATURAL_LANGUAGE_CLASSIFIER_URL: placeholder

--- a/server/env.example
+++ b/server/env.example
@@ -1,6 +1,6 @@
 # Replace the credentials here with your own.
 # Rename this file to .env before running 'npm start'.
 
-NATURAL_LANGUAGE_CLASSIFIER_USERNAME=<add_NLC_username>
-NATURAL_LANGUAGE_CLASSIFIER_PASSWORD=<add_NLC_password>
+NATURAL_LANGUAGE_CLASSIFIER_APIKEY=<your_nlc_apikey>
+NATURAL_LANGUAGE_CLASSIFIER_URL=<your_nlc_url>
 CLASSIFIER_ID=<add_ModelID>

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -28,7 +28,7 @@
 
     function renderAnswer(data) {
         if (!data.classes || !data.classes.length > 0) {
-            $('.answer').html('Something went wrong :-(');
+            $('.answer').html(data);
         } else {
             var top = data.classes[0]
             $('.answer').html(top.class_name.toUpperCase());

--- a/server/routes/classify.js
+++ b/server/routes/classify.js
@@ -56,6 +56,7 @@ function classify(req, res) {
   }, function(err,response){
     if (err) {
       console.log(err)
+      res.json(err.body)
     } else {
       res.json(response.result)
     }


### PR DESCRIPTION
The .env and manifest were still using the username/password
convention. This PR changes those files to api key and URL,
which are already used in the code base.

Also, `domain` in manifest.yml is deprecated.

Additionally, one minor change to make the message a bit more
useful when an error is returned. For instance, now it'll
show the the model is still being trained, rather than a
not useful, even if comical, frowny face.